### PR TITLE
Re-enable TLS certificate validation in background HTTP client

### DIFF
--- a/custom_components/tibber_grid_reward/__init__.py
+++ b/custom_components/tibber_grid_reward/__init__.py
@@ -21,7 +21,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Tibber Grid Reward from a config entry."""
     hass.data.setdefault(DOMAIN, {})
 
-    client = get_async_client(hass, verify_ssl=False)
+    client = get_async_client(hass)
 
     api = TibberAPI(
         entry.data["username"],


### PR DESCRIPTION
## Summary

`async_setup_entry` creates the async HTTP client used for all live Tibber app-API traffic with `verify_ssl=False`. This disables TLS certificate validation for:

- the credential `POST` to `app.tibber.com/v1/login.credentials` (carries username + password)
- subsequent token-refresh POSTs
- GraphQL queries against `app.tibber.com/v4/gql` (carry Bearer token + Grid Rewards payload)

`app.tibber.com` serves a valid publicly-trusted certificate, so bypassing verification only weakens the integration: an attacker able to impersonate `app.tibber.com` (rogue Wi-Fi, misconfigured proxy/VPN, DNS rebinding) can capture the user's Tibber credentials and live session tokens.

`config_flow.py` already uses `get_async_client(hass)` with the default `verify_ssl=True`, so this is also an internal inconsistency between setup and runtime.

## Change

```diff
-    client = get_async_client(hass, verify_ssl=False)
+    client = get_async_client(hass)
```

## Test plan

- [ ] Re-install the integration; credentials POST succeeds (cert is valid, so verification passes).
- [ ] WebSocket subscription continues to deliver Grid Reward state and earnings updates.
- [ ] `set_departure_time` service still works.

Tested on Home Assistant Core 2026.5.1.