### PR TITLE
Add battery activity reason sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a custom integration for Home Assistant that allows you to monitor and i
 
 - **Grid Reward Sensors**: Provides sensors for the current state of the grid reward, the reason for the current state, and the earnings for the current day and month.
 - **Live Session Reward**: A sensor that shows the live, accumulating reward amount during an active grid reward session.
+- **Battery Activity Reason**: For home batteries, a sensor showing *why* the battery is charging, discharging or idle right now — `charging_for_grid_rewards`, `discharging_at_high_price`, `charging_with_solar_production`, `limited_by_fuse_protection` and so on. This distinguishes grid reward activity from ordinary price arbitrage, which is not otherwise visible.
 - **Flexible Device Sensors**: Provides sensors for the state and connectivity of your flexible devices (e.g., electric vehicles).
 - **Departure Time Control**: Allows you to set the departure time for your electric vehicles directly from Home Assistant.
 

--- a/custom_components/tibber_grid_reward/client.py
+++ b/custom_components/tibber_grid_reward/client.py
@@ -4,6 +4,7 @@ import logging
 import ssl
 import time
 import uuid
+from datetime import datetime, timedelta, timezone
 from collections.abc import Callable
 from typing import Any
 
@@ -84,6 +85,68 @@ class TibberAPI:
             response.raise_for_status()
             _LOGGER.debug("Successfully fetched Tibber homes.")
             return response.json().get("data", {}).get("me", {}).get("homes", [])
+        except httpx.HTTPStatusError as e:
+            raise TibberConnectionError from e
+        except Exception as e:
+            raise TibberException from e
+
+    async def get_battery_activity(
+        self, home_id: str, battery_id: str, hours_back: int = 6
+    ) -> list[dict[str, Any]]:
+        """Fetch recent battery activity intervals.
+
+        Each interval carries the reason the battery behaved the way it did,
+        as a GraphQL type name such as HomeBatteryChargingForGridRewards or
+        HomeBatteryDischargingAtHighPrice. The interval currently in progress
+        has a null "to".
+
+        Only __typename is requested rather than the app's full fragment; the
+        concrete payloads only add a validUntil that duplicates "to".
+        """
+        _LOGGER.debug("Fetching battery activity for battery %s", battery_id)
+        token = await self.fetch_token()
+        headers = {"Authorization": f"Bearer {token}"}
+        now = datetime.now(timezone.utc)
+        payload = {
+            "operationName": "GetBatteryActivity",
+            "variables": {
+                "homeId": home_id,
+                "deviceId": battery_id,
+                "from": (now - timedelta(hours=hours_back)).strftime(
+                    "%Y-%m-%dT%H:%M:%SZ"
+                ),
+                "to": (now + timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+            "query": """
+            query GetBatteryActivity(
+              $homeId: String!, $deviceId: String!, $from: DateTime!, $to: DateTime!
+            ) {
+              me {
+                home(id: $homeId) {
+                  batteryActivityHistory(id: $deviceId, from: $from, to: $to) {
+                    items {
+                      from
+                      to
+                      reason { __typename }
+                      secondaryReason { __typename }
+                    }
+                  }
+                }
+              }
+            }
+            """,
+        }
+        try:
+            response = await self._client.post(GRAPHQL_URL, headers=headers, json=payload)
+            response.raise_for_status()
+            data = response.json().get("data") or {}
+            history = (
+                ((data.get("me") or {}).get("home") or {}).get(
+                    "batteryActivityHistory"
+                )
+                or {}
+            )
+            return history.get("items") or []
         except httpx.HTTPStatusError as e:
             raise TibberConnectionError from e
         except Exception as e:

--- a/custom_components/tibber_grid_reward/sensor.py
+++ b/custom_components/tibber_grid_reward/sensor.py
@@ -55,6 +55,31 @@ GRID_REWARD_SENSORS: tuple[SensorEntityDescription, ...] = (
     ),
 )
 
+BATTERY_ACTIVITY_SENSOR_DESCRIPTION = SensorEntityDescription(
+    key="battery_activity_reason",
+    name="Activity Reason",
+    icon="mdi:home-battery",
+)
+
+# Tibber reports the reason as a GraphQL type name. Strip the shared prefix and
+# expose snake_case so the value reads as a state rather than a class name:
+# HomeBatteryChargingForGridRewards -> charging_for_grid_rewards
+_REASON_PREFIX = "HomeBattery"
+
+
+def _reason_to_state(typename: str | None) -> str | None:
+    """Turn a reason type name into a snake_case sensor state."""
+    if not typename:
+        return None
+    name = typename[len(_REASON_PREFIX):] if typename.startswith(_REASON_PREFIX) else typename
+    out = []
+    for i, char in enumerate(name):
+        if char.isupper() and i:
+            out.append("_")
+        out.append(char.lower())
+    return "".join(out)
+
+
 FLEX_DEVICE_SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
         key="state",
@@ -118,6 +143,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for description in FLEX_DEVICE_SENSORS:
             grid_reward_sensors.append(
                 FlexDeviceSensor(api, config_entry.entry_id, device, description)
+            )
+        if device.get("type") == "battery":
+            sensors.append(
+                BatteryActivitySensor(
+                    api,
+                    config_entry.data["home_id"],
+                    config_entry.entry_id,
+                    device,
+                    BATTERY_ACTIVITY_SENSOR_DESCRIPTION,
+                )
             )
         if device.get("type") == "vehicle":
             vehicle_id = device["id"]
@@ -223,6 +258,57 @@ class RewardSessionSensor(GridRewardSensor):
             self._attr_native_unit_of_measurement = data.get("rewardCurrency")
             return self._session_tracker.current_session_reward
         return None
+
+
+class BatteryActivitySensor(SensorEntity):
+    """Why the battery is doing what it is doing right now.
+
+    Tibber labels each activity interval with a reason, which distinguishes
+    grid rewards from price arbitrage, solar charging and fuse protection —
+    something that cannot be told apart from the inverter side.
+    """
+
+    entity_description: SensorEntityDescription
+
+    def __init__(self, api, home_id, entry_id, device, description):
+        self.entity_description = description
+        self._api = api
+        self._home_id = home_id
+        self._entry_id = entry_id
+        self._device_id = device["id"]
+        self._device_name = device.get("name", self._device_id)
+        self._attr_unique_id = f"{self._device_id}_{description.key}"
+        self._attr_name = f"{self._device_name} {description.name}"
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": self._device_name,
+            "manufacturer": "Tibber",
+            "via_device": (DOMAIN, self._entry_id),
+        }
+
+    async def async_update(self) -> None:
+        """Fetch new state data for the sensor."""
+        items = await self._api.get_battery_activity(self._home_id, self._device_id)
+        if not items:
+            self._attr_native_value = None
+            self._attr_extra_state_attributes = {}
+            return
+
+        # The interval in progress is the one that has not ended yet. Fall back
+        # to the most recent one if the API has already closed it.
+        current = next((i for i in items if not i.get("to")), items[-1])
+        reason = (current.get("reason") or {}).get("__typename")
+        secondary = (current.get("secondaryReason") or {}).get("__typename")
+
+        self._attr_native_value = _reason_to_state(reason)
+        self._attr_extra_state_attributes = {
+            "reason_raw": reason,
+            "secondary_reason": _reason_to_state(secondary),
+            "since": current.get("from"),
+        }
 
 
 class FlexDeviceSensor(SensorEntity):


### PR DESCRIPTION
Adds a sensor showing *why* the home battery is doing what it is doing right
now — the data behind the app's "Batteriaktivitet" screen.

## Where the value comes from

Captured from the app's `GetBatteryActivityHistory` query:

```graphql
me { home(id: $homeId) {
  batteryActivityHistory(id: $deviceId, from: $from, to: $to) {
    items { from to reason { __typename } secondaryReason { __typename } }
  }
} }
```

Each interval is labelled with a reason type. The full set the app enumerates
includes `HomeBatteryChargingForGridRewards`,
`HomeBatteryDischargingForGridRewards`, `HomeBatteryIdleForGridRewards`,
`HomeBatteryChargingAtLowPrice`, `HomeBatteryDischargingAtHighPrice`,
`HomeBatteryChargingWithSolarProduction`, `HomeBatteryLimitedByFuseProtection`
and about fifteen more.

The interval currently in progress is the one with a null `to`.

Sample from a live account:

```
13:28→13:30  HomeBatteryChargingForGridRewards
13:58→14:13  HomeBatteryDischargingForGridRewards
14:16→14:31  HomeBatteryChargingWithSolarProduction
15:01→15:13  HomeBatteryChargingAtLowPrice
```

## What this adds

One sensor per battery flex device, `<battery> Activity Reason`, with the
reason as a snake_case state (`charging_for_grid_rewards`,
`discharging_at_high_price`, ...) and `reason_raw`, `secondary_reason` and
`since` as attributes.

## Why it seems worth having

This is the only place the API distinguishes grid reward activity from
ordinary price arbitrage. Both look identical from the inverter side — the
battery just receives a setpoint — so without this there is no way to tell
whether a discharge is earning grid rewards or simply selling at a good price.

## Note on the query

Only `__typename` is requested rather than the app's full inline-fragment set;
the concrete payloads only add a `validUntil` that duplicates `to`. Verified
against a live account that the server accepts this.

Independent of #39 — branched from main, no overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)