### PR TITLE
Add battery planned activity sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a custom integration for Home Assistant that allows you to monitor and i
 
 - **Grid Reward Sensors**: Provides sensors for the current state of the grid reward, the reason for the current state, and the earnings for the current day and month.
 - **Live Session Reward**: A sensor that shows the live, accumulating reward amount during an active grid reward session.
+- **Battery Planned Activity**: For home batteries, a sensor whose state is the start of the next planned charge or discharge, with Tibber's full quarter-hourly plan (power and forecast state of charge, through tomorrow) as an attribute for charting.
 - **Flexible Device Sensors**: Provides sensors for the state and connectivity of your flexible devices (e.g., electric vehicles).
 - **Departure Time Control**: Allows you to set the departure time for your electric vehicles directly from Home Assistant.
 

--- a/custom_components/tibber_grid_reward/client.py
+++ b/custom_components/tibber_grid_reward/client.py
@@ -4,6 +4,7 @@ import logging
 import ssl
 import time
 import uuid
+from datetime import datetime, timedelta, timezone
 from collections.abc import Callable
 from typing import Any
 
@@ -88,6 +89,78 @@ class TibberAPI:
             raise TibberConnectionError from e
         except Exception as e:
             raise TibberException from e
+
+    async def get_battery_planned_activity(
+        self, home_id: str, battery_id: str, days_ahead: int = 1
+    ) -> list[dict[str, Any]]:
+        """Fetch the battery's planned activity from now until end of tomorrow.
+
+        This is the data behind the app's "Batteriaktivitet" chart. Items are
+        quarter-hourly and marked FORECAST for the part that has not happened
+        yet. Charge and discharge are in watts; state of charge is a percentage.
+
+        Only the forward-looking part is returned — history is already
+        available from the battery's own sensors. The per-source breakdown
+        (chargedFromSolar and friends) is only populated for historical items,
+        so it is left out.
+        """
+        _LOGGER.debug("Fetching planned activity for battery %s", battery_id)
+        token = await self.fetch_token()
+        headers = {"Authorization": f"Bearer {token}"}
+        now = datetime.now(timezone.utc)
+        end = (now + timedelta(days=days_ahead)).replace(
+            hour=23, minute=59, second=59, microsecond=0
+        )
+        payload = {
+            "operationName": "GetBatteryPlannedActivity",
+            "variables": {
+                "homeId": home_id,
+                "deviceId": battery_id,
+                "from": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "to": end.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                "resolution": "QUARTER_HOURLY",
+            },
+            "query": """
+            query GetBatteryPlannedActivity(
+              $homeId: String!, $deviceId: String!, $from: DateTime!,
+              $to: DateTime!, $resolution: BatteryTimelineResolution!
+            ) {
+              me { home(id: $homeId) {
+                batteryTimeline(
+                  id: $deviceId, from: $from, to: $to, resolution: $resolution
+                ) {
+                  energyFlow { items { kind time charged discharged } }
+                  stateOfCharge { items { kind time stateOfCharge } }
+                }
+              } }
+            }
+            """,
+        }
+        try:
+            response = await self._client.post(GRAPHQL_URL, headers=headers, json=payload)
+            response.raise_for_status()
+            data = response.json().get("data") or {}
+            timeline = (((data.get("me") or {}).get("home") or {})
+                        .get("batteryTimeline") or {})
+        except httpx.HTTPStatusError as e:
+            raise TibberConnectionError from e
+        except Exception as e:
+            raise TibberException from e
+
+        soc_by_time = {
+            item.get("time"): item.get("stateOfCharge")
+            for item in ((timeline.get("stateOfCharge") or {}).get("items") or [])
+        }
+        planned: list[dict[str, Any]] = []
+        for item in (timeline.get("energyFlow") or {}).get("items") or []:
+            planned.append({
+                "time": item.get("time"),
+                "kind": item.get("kind"),
+                "charged": item.get("charged"),
+                "discharged": item.get("discharged"),
+                "state_of_charge": soc_by_time.get(item.get("time")),
+            })
+        return planned
 
     async def set_smart_charging_enabled(self, home_id: str, vehicle_id: str, enabled: bool) -> None:
         _LOGGER.debug("Setting smart charging enabled to %s for vehicle %s", enabled, vehicle_id)

--- a/custom_components/tibber_grid_reward/sensor.py
+++ b/custom_components/tibber_grid_reward/sensor.py
@@ -1,5 +1,6 @@
 """Platform for sensor integration."""
 import logging
+from datetime import timedelta
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -54,6 +55,21 @@ GRID_REWARD_SENSORS: tuple[SensorEntityDescription, ...] = (
         device_class=SensorDeviceClass.MONETARY,
     ),
 )
+
+BATTERY_PLANNED_SENSOR_DESCRIPTION = SensorEntityDescription(
+    key="battery_planned_activity",
+    name="Next Planned Activity",
+    device_class=SensorDeviceClass.TIMESTAMP,
+    icon="mdi:calendar-clock",
+)
+
+# The plan barely changes between polls and the payload is a few kilobytes,
+# so there is no point fetching it at the platform's default interval.
+PLANNED_MIN_INTERVAL = timedelta(minutes=15)
+
+# Below this the interval is noise rather than a planned event.
+PLANNED_POWER_THRESHOLD_W = 100
+
 
 FLEX_DEVICE_SENSORS: tuple[SensorEntityDescription, ...] = (
     SensorEntityDescription(
@@ -118,6 +134,16 @@ async def async_setup_entry(hass, config_entry, async_add_entities):
         for description in FLEX_DEVICE_SENSORS:
             grid_reward_sensors.append(
                 FlexDeviceSensor(api, config_entry.entry_id, device, description)
+            )
+        if device.get("type") == "battery":
+            sensors.append(
+                BatteryPlannedActivitySensor(
+                    api,
+                    config_entry.data["home_id"],
+                    config_entry.entry_id,
+                    device,
+                    BATTERY_PLANNED_SENSOR_DESCRIPTION,
+                )
             )
         if device.get("type") == "vehicle":
             vehicle_id = device["id"]
@@ -223,6 +249,93 @@ class RewardSessionSensor(GridRewardSensor):
             self._attr_native_unit_of_measurement = data.get("rewardCurrency")
             return self._session_tracker.current_session_reward
         return None
+
+
+class BatteryPlannedActivitySensor(SensorEntity):
+    """When the battery next plans to charge or discharge.
+
+    The state is the start of the next planned event, so it can be used in
+    automations directly. The full quarter-hourly plan is exposed as an
+    attribute for charting.
+    """
+
+    entity_description: SensorEntityDescription
+
+    def __init__(self, api, home_id, entry_id, device, description):
+        self.entity_description = description
+        self._api = api
+        self._home_id = home_id
+        self._entry_id = entry_id
+        self._device_id = device["id"]
+        self._device_name = device.get("name", self._device_id)
+        self._attr_unique_id = f"{self._device_id}_{description.key}"
+        self._attr_name = f"{self._device_name} {description.name}"
+        self._fetched_at = None
+        self._planned: list[dict] = []
+
+    @property
+    def device_info(self):
+        return {
+            "identifiers": {(DOMAIN, self._device_id)},
+            "name": self._device_name,
+            "manufacturer": "Tibber",
+            "via_device": (DOMAIN, self._entry_id),
+        }
+
+    async def async_update(self) -> None:
+        """Fetch new state data for the sensor."""
+        now = dt_util.utcnow()
+        if self._fetched_at is None or now - self._fetched_at >= PLANNED_MIN_INTERVAL:
+            self._planned = await self._api.get_battery_planned_activity(
+                self._home_id, self._device_id
+            )
+            self._fetched_at = now
+
+        forecast = [p for p in self._planned if p.get("kind") == "FORECAST"]
+        nxt = next(
+            (
+                p
+                for p in forecast
+                if (p.get("charged") or 0) >= PLANNED_POWER_THRESHOLD_W
+                or (p.get("discharged") or 0) >= PLANNED_POWER_THRESHOLD_W
+            ),
+            None,
+        )
+
+        self._attr_native_value = (
+            dt_util.parse_datetime(nxt["time"]) if nxt and nxt.get("time") else None
+        )
+        self._attr_extra_state_attributes = {
+            "next_action": (
+                None
+                if not nxt
+                else "charge"
+                if (nxt.get("charged") or 0) >= PLANNED_POWER_THRESHOLD_W
+                else "discharge"
+            ),
+            "next_power_w": (
+                None
+                if not nxt
+                else (nxt.get("charged") or 0) or (nxt.get("discharged") or 0)
+            ),
+            # Trimmed rather than passed through: "kind" is the same for every
+            # item once filtered, and the API returns state of charge with more
+            # decimals than are meaningful. The full payload would otherwise
+            # sit close to Home Assistant's attribute size warning.
+            "forecast": [
+                {
+                    "time": p.get("time"),
+                    "charged": p.get("charged"),
+                    "discharged": p.get("discharged"),
+                    "state_of_charge": (
+                        None
+                        if p.get("state_of_charge") is None
+                        else round(p["state_of_charge"], 1)
+                    ),
+                }
+                for p in forecast
+            ],
+        }
 
 
 class FlexDeviceSensor(SensorEntity):


### PR DESCRIPTION
Exposes Tibber's *plan* for the home battery — the forecast half of the app's
"Batteriaktivitet" chart, labelled "Planerad Händelse" in the legend.

## Where the value comes from

Captured from the app's `GetBatteryTimeline` query:

```graphql
batteryTimeline(id: $deviceId, from: $from, to: $to, resolution: QUARTER_HOURLY) {
  energyFlow    { items { kind time charged discharged } }
  stateOfCharge { items { kind time stateOfCharge } }
}
```

Items are marked `HISTORICAL` or `FORECAST`, so asking for a window that
extends into tomorrow returns the plan.

## What this adds

One sensor per battery flex device, `<battery> Next Planned Activity`:

- **State**: timestamp of the next planned charge or discharge, so it can be
  used in automations directly (`device_class: timestamp`).
- **Attributes**: `next_action` (charge/discharge), `next_power_w`, and
  `forecast` — the quarter-hourly plan through tomorrow with power and
  forecast state of charge per point.

Sample from a live account:

```
state: 2026-09-02T17:45:00+00:00
next_action: discharge
next_power_w: 3000

forecast:
  17:45  discharge 3000 W  soc 93.9
  18:15  discharge 2342 W  soc 78.4
  18:30  discharge 2342 W  soc 65.6
  19:00  discharge  439 W  soc 42.2
```

## Design notes

Three things were trimmed deliberately, all for payload size — the untrimmed
response is around 15 kB, uncomfortably close to Home Assistant's attribute
size warning:

- Only the forward-looking window is fetched. History is already available
  from the battery's own sensors.
- The per-source breakdown (`chargedFromSolar`, `dischargedToGrid`, ...) is
  left out — the API only populates those for historical items and returns
  null across the whole forecast.
- `kind` is dropped from the attribute since every remaining item is
  `FORECAST`, and state of charge is rounded to one decimal.

That brings it to roughly 13 kB. The plan is also fetched at most every 15
minutes rather than on every platform poll, since it barely changes.

Independent of #39 and #41 — branched from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)